### PR TITLE
add new chunktensor index kernel transplanted from wholegraph

### DIFF
--- a/src/chunk_tensor.cu
+++ b/src/chunk_tensor.cu
@@ -47,4 +47,47 @@ torch::Tensor ChunkTensor::Index(torch::Tensor index) {
 
   return torch::Tensor();
 }
+
+template <typename ValueType, typename IndexType>
+void __global__ _WholeGraphIndexMemcpyKernel(
+    chunk_tensor_wrapper<ValueType>* data, const IndexType* const index,
+    const int indice_count, const int group_count, const int entry_count,
+    ValueType* const output) {
+  int64_t thread_idx = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
+  int64_t idx = thread_idx / group_count;
+  if (idx >= indice_count) return;
+  int64_t src_idx = index[idx] % entry_count;
+  int lane_idx = thread_idx % group_count;
+  output[thread_idx] = data->At(src_idx * group_count + lane_idx);
+}
+
+torch::Tensor ChunkTensor::WholeGraphIndex(torch::Tensor index) {
+  CHECK_CUDA(index);
+  DGS_VALUE_TYPE_SWITCH(type_, ValueType, {
+    DGS_ID_TYPE_SWITCH(index.dtype(), IndexType, {
+      int entry_count = total_tensor_size_;
+      int group_count = stride_;
+      int indice_count = index.numel();
+      torch::Tensor out_data = torch::empty(
+          {indice_count, stride_},
+          torch::TensorOptions().dtype(type_).device(torch::kCUDA));
+      chunk_tensor_wrapper<ValueType>* data_wrapper_ptr =
+          reinterpret_cast<chunk_tensor_wrapper<ValueType>*>(wrapper_ptr_);
+
+      int thread_count = group_count;
+      if (thread_count < 64) thread_count = 64;
+      int group_per_block = thread_count / group_count;
+      int block_count = (indice_count + group_per_block - 1) / group_per_block;
+      _WholeGraphIndexMemcpyKernel<ValueType, IndexType>
+          <<<block_count, thread_count>>>(
+              data_wrapper_ptr, index.data_ptr<IndexType>(), indice_count,
+              group_count, entry_count, out_data.data_ptr<ValueType>());
+
+      return out_data;
+    });
+  });
+
+  return torch::Tensor();
+}
+
 }  // namespace dgs

--- a/src/chunk_tensor.h
+++ b/src/chunk_tensor.h
@@ -154,6 +154,7 @@ class ChunkTensor : public torch::CustomClassHolder {
   }
 
   torch::Tensor Index(torch::Tensor index);
+  torch::Tensor WholeGraphIndex(torch::Tensor index);
 
   void _CreateWrapperPtr() {
     DGS_VALUE_TYPE_SWITCH(type_, ValueType, {

--- a/src/pybind.cc
+++ b/src/pybind.cc
@@ -13,7 +13,8 @@ TORCH_LIBRARY(dgs_classes, m) {
       .def(torch::init<torch::Tensor, int64_t>())
       .def("_CAPI_get_host_tensor", &ChunkTensor::GetHostTensor)
       .def("_CAPI_get_sub_device_tensor", &ChunkTensor::GetSubDeviceTensor)
-      .def("_CAPI_index", &ChunkTensor::Index);
+      .def("_CAPI_index", &ChunkTensor::Index)
+      .def("_CAPI_index_whole_graph", &ChunkTensor::WholeGraphIndex);
 }
 
 TORCH_LIBRARY(dgs_ops, m) {


### PR DESCRIPTION
bench result:

```text
GPU: 1080ti * 2
Data size: 10000000 * 128 * sizeof(float32) = 4.77 GB

Ours:
GPU 0 | Nodes per iteration 500 | Host cache rate 0.000 | Local cache rate 0.500 | Loading time 0.06 ms
GPU 1 | Nodes per iteration 500 | Host cache rate 0.000 | Local cache rate 0.500 | Loading time 0.08 ms
GPU 0 | Nodes per iteration 5000 | Host cache rate 0.000 | Local cache rate 0.500 | Loading time 0.29 ms
GPU 1 | Nodes per iteration 5000 | Host cache rate 0.000 | Local cache rate 0.500 | Loading time 0.29 ms
GPU 1 | Nodes per iteration 50000 | Host cache rate 0.000 | Local cache rate 0.500 | Loading time 2.65 ms
GPU 0 | Nodes per iteration 50000 | Host cache rate 0.000 | Local cache rate 0.500 | Loading time 2.85 ms
GPU 1 | Nodes per iteration 500000 | Host cache rate 0.000 | Local cache rate 0.500 | Loading time 21.53 ms
GPU 0 | Nodes per iteration 500000 | Host cache rate 0.000 | Local cache rate 0.500 | Loading time 22.81 ms
GPU 1 | Nodes per iteration 5000000 | Host cache rate 0.000 | Local cache rate 0.500 | Loading time 140.05 ms
GPU 0 | Nodes per iteration 5000000 | Host cache rate 0.000 | Local cache rate 0.500 | Loading time 138.91 ms
GPU 0 | Nodes per iteration 500 | Host cache rate 0.500 | Local cache rate 0.250 | Loading time 0.06 ms
GPU 1 | Nodes per iteration 500 | Host cache rate 0.500 | Local cache rate 0.250 | Loading time 0.09 ms
GPU 0 | Nodes per iteration 5000 | Host cache rate 0.500 | Local cache rate 0.250 | Loading time 0.26 ms
GPU 1 | Nodes per iteration 5000 | Host cache rate 0.500 | Local cache rate 0.250 | Loading time 0.25 ms
GPU 1 | Nodes per iteration 50000 | Host cache rate 0.500 | Local cache rate 0.250 | Loading time 2.18 ms
GPU 0 | Nodes per iteration 50000 | Host cache rate 0.500 | Local cache rate 0.250 | Loading time 2.37 ms
GPU 1 | Nodes per iteration 500000 | Host cache rate 0.500 | Local cache rate 0.250 | Loading time 19.01 ms
GPU 0 | Nodes per iteration 500000 | Host cache rate 0.500 | Local cache rate 0.250 | Loading time 19.00 ms
GPU 0 | Nodes per iteration 5000000 | Host cache rate 0.500 | Local cache rate 0.250 | Loading time 192.11 ms
GPU 1 | Nodes per iteration 5000000 | Host cache rate 0.500 | Local cache rate 0.250 | Loading time 187.19 ms
GPU 0 | Nodes per iteration 500 | Host cache rate 1.000 | Local cache rate 0.000 | Loading time 0.08 ms
GPU 1 | Nodes per iteration 500 | Host cache rate 1.000 | Local cache rate 0.000 | Loading time 0.09 ms
GPU 0 | Nodes per iteration 5000 | Host cache rate 1.000 | Local cache rate 0.000 | Loading time 0.27 ms
GPU 1 | Nodes per iteration 5000 | Host cache rate 1.000 | Local cache rate 0.000 | Loading time 0.28 ms
GPU 1 | Nodes per iteration 50000 | Host cache rate 1.000 | Local cache rate 0.000 | Loading time 2.26 ms
GPU 0 | Nodes per iteration 50000 | Host cache rate 1.000 | Local cache rate 0.000 | Loading time 2.26 ms
GPU 1 | Nodes per iteration 500000 | Host cache rate 1.000 | Local cache rate 0.000 | Loading time 22.12 ms
GPU 0 | Nodes per iteration 500000 | Host cache rate 1.000 | Local cache rate 0.000 | Loading time 22.18 ms
GPU 0 | Nodes per iteration 5000000 | Host cache rate 1.000 | Local cache rate 0.000 | Loading time 190.86 ms
GPU 1 | Nodes per iteration 5000000 | Host cache rate 1.000 | Local cache rate 0.000 | Loading time 191.34 ms

Wholegraph kernel:
GPU 0 | Nodes per iteration 500 | Host cache rate 0.000 | Local cache rate 0.500 | Loading time 0.06 ms
GPU 1 | Nodes per iteration 500 | Host cache rate 0.000 | Local cache rate 0.500 | Loading time 0.08 ms
GPU 1 | Nodes per iteration 5000 | Host cache rate 0.000 | Local cache rate 0.500 | Loading time 0.19 ms
GPU 0 | Nodes per iteration 5000 | Host cache rate 0.000 | Local cache rate 0.500 | Loading time 0.19 ms
GPU 1 | Nodes per iteration 50000 | Host cache rate 0.000 | Local cache rate 0.500 | Loading time 1.51 ms
GPU 0 | Nodes per iteration 50000 | Host cache rate 0.000 | Local cache rate 0.500 | Loading time 1.51 ms
GPU 0 | Nodes per iteration 500000 | Host cache rate 0.000 | Local cache rate 0.500 | Loading time 24.55 ms
GPU 1 | Nodes per iteration 500000 | Host cache rate 0.000 | Local cache rate 0.500 | Loading time 25.92 ms
GPU 0 | Nodes per iteration 5000000 | Host cache rate 0.000 | Local cache rate 0.500 | Loading time 146.37 ms
GPU 1 | Nodes per iteration 5000000 | Host cache rate 0.000 | Local cache rate 0.500 | Loading time 135.44 ms
GPU 1 | Nodes per iteration 500 | Host cache rate 0.500 | Local cache rate 0.250 | Loading time 0.06 ms
GPU 0 | Nodes per iteration 500 | Host cache rate 0.500 | Local cache rate 0.250 | Loading time 0.07 ms
GPU 0 | Nodes per iteration 5000 | Host cache rate 0.500 | Local cache rate 0.250 | Loading time 0.23 ms
GPU 1 | Nodes per iteration 5000 | Host cache rate 0.500 | Local cache rate 0.250 | Loading time 0.24 ms
GPU 1 | Nodes per iteration 50000 | Host cache rate 0.500 | Local cache rate 0.250 | Loading time 2.16 ms
GPU 0 | Nodes per iteration 50000 | Host cache rate 0.500 | Local cache rate 0.250 | Loading time 2.13 ms
GPU 0 | Nodes per iteration 500000 | Host cache rate 0.500 | Local cache rate 0.250 | Loading time 19.73 ms
GPU 1 | Nodes per iteration 500000 | Host cache rate 0.500 | Local cache rate 0.250 | Loading time 19.70 ms
GPU 1 | Nodes per iteration 5000000 | Host cache rate 0.500 | Local cache rate 0.250 | Loading time 163.16 ms
GPU 0 | Nodes per iteration 5000000 | Host cache rate 0.500 | Local cache rate 0.250 | Loading time 162.70 ms
GPU 1 | Nodes per iteration 500 | Host cache rate 1.000 | Local cache rate 0.000 | Loading time 0.11 ms
GPU 0 | Nodes per iteration 500 | Host cache rate 1.000 | Local cache rate 0.000 | Loading time 0.10 ms
GPU 1 | Nodes per iteration 5000 | Host cache rate 1.000 | Local cache rate 0.000 | Loading time 0.31 ms
GPU 0 | Nodes per iteration 5000 | Host cache rate 1.000 | Local cache rate 0.000 | Loading time 0.30 ms
GPU 0 | Nodes per iteration 50000 | Host cache rate 1.000 | Local cache rate 0.000 | Loading time 2.30 ms
GPU 1 | Nodes per iteration 50000 | Host cache rate 1.000 | Local cache rate 0.000 | Loading time 2.30 ms
GPU 1 | Nodes per iteration 500000 | Host cache rate 1.000 | Local cache rate 0.000 | Loading time 22.19 ms
GPU 0 | Nodes per iteration 500000 | Host cache rate 1.000 | Local cache rate 0.000 | Loading time 22.18 ms
GPU 0 | Nodes per iteration 5000000 | Host cache rate 1.000 | Local cache rate 0.000 | Loading time 198.63 ms
GPU 1 | Nodes per iteration 5000000 | Host cache rate 1.000 | Local cache rate 0.000 | Loading time 198.53 ms
```